### PR TITLE
Jamtis subaddresses

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 GOPATH ?= $(shell go env GOPATH)
-LINTER_VERSION = "1.54.1"
+LINTER_VERSION = "1.54.2"
 LINTER = $(GOPATH)/bin/golangci-lint
 
 .PHONY: all

--- a/jamtis/blake2bhash.go
+++ b/jamtis/blake2bhash.go
@@ -1,0 +1,36 @@
+package jamtis
+
+import (
+	ed25519 "filippo.io/edwards25519"
+	"golang.org/x/crypto/blake2b"
+)
+
+func blake2bHash(optionalKey []byte, hashSize int, inputs ...any) ([]byte, error) {
+	h, err := blake2b.New(hashSize, optionalKey)
+	if err != nil {
+		return nil, err
+	}
+
+	for _, input := range inputs {
+		var inputBytes []byte
+		switch arg := input.(type) {
+		case string:
+			inputBytes = []byte(arg)
+		case []byte:
+			inputBytes = arg
+		case *ed25519.Scalar:
+			inputBytes = arg.Bytes()
+		case *ed25519.Point:
+			inputBytes = arg.Bytes()
+		default:
+			panic("invalid hash input type")
+		}
+
+		_, err = h.Write(inputBytes)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	return h.Sum(nil), nil
+}

--- a/jamtis/blake2bhash.go
+++ b/jamtis/blake2bhash.go
@@ -5,6 +5,9 @@ import (
 	"golang.org/x/crypto/blake2b"
 )
 
+// blake2bHash returns the blake2b hash of the inputs concatenated together.
+// Inputs of type string, *ed25519.Scalar, and *ed25519.Point are automatically
+// converted to bytes before hashing.
 func blake2bHash(optionalKey []byte, hashSize int, inputs ...any) ([]byte, error) {
 	h, err := blake2b.New(hashSize, optionalKey)
 	if err != nil {

--- a/jamtis/jamtis.go
+++ b/jamtis/jamtis.go
@@ -5,9 +5,28 @@
 package jamtis
 
 import (
+	ed25519 "filippo.io/edwards25519"
 	"golang.org/x/crypto/blake2b"
 	"golang.org/x/crypto/curve25519"
+	"golang.org/x/crypto/twofish"
+
+	"github.com/dimalinux/gopherphis/mcrypto"
 )
+
+const (
+	prefix                               = "monero"
+	hashKeyJamtisIndexExtensionGenerator = "jamtis_index_extension_generator"
+	hashKeyJamtisSpendKeyExtensionG      = "jamtis_spendkey_extension_g"
+	hashKeyJamtisSpendKeyExtensionX      = "jamtis_spendkey_extension_x"
+	hashKeyJamtisSpendKeyExtensionU      = "jamtis_spendkey_extension_u"
+)
+
+type Address struct {
+	K1  []byte
+	K2  []byte
+	K3  []byte
+	Tag []byte
+}
 
 func keyDerive1(key []byte, name string) ([]byte, error) {
 	const prefix = "monero"
@@ -75,4 +94,197 @@ func genFindReceivedPubKey(findReceivedPrivKey []byte, unlockAmountsPubKey []byt
 	var pubKey [32]byte
 	x25519ScalarMult(pubKey[:], findReceivedPrivKey, unlockAmountsPubKey)
 	return pubKey[:]
+}
+
+func genJamtisAddressV1(
+	spendPubKey []byte,
+	unlockAmountsPubKey []byte,
+	findReceivedPubKey []byte,
+	generateAddressPrivKey []byte,
+	addressIndex []byte,
+) (*Address, error) {
+
+	K1, err := genJamtisAddressSpendKey(spendPubKey, generateAddressPrivKey, addressIndex)
+	if err != nil {
+		return nil, err
+	}
+
+	addressPrivKey, err := genJamtisAddressPrivKey(spendPubKey, generateAddressPrivKey, addressIndex)
+	if err != nil {
+		return nil, err
+	}
+
+	K2 := make([]byte, 32)
+	x25519ScalarMult(K2, addressPrivKey, findReceivedPubKey)
+
+	K3 := make([]byte, 32)
+	x25519ScalarMult(K3, addressPrivKey, unlockAmountsPubKey)
+
+	cipherTagSecret, err := genCipherTagSecret(generateAddressPrivKey)
+	if err != nil {
+		return nil, err
+	}
+
+	cipher, err := twofish.NewCipher(cipherTagSecret)
+	if err != nil {
+		return nil, err
+	}
+
+	encryptedAddressIndexAndHint := make([]byte, cipher.BlockSize()+2)
+	encryptedAddressIndex := encryptedAddressIndexAndHint[0:cipher.BlockSize()]
+	//hint := encryptedAddressIndexAndHint[cipher.BlockSize():]
+	// Encrypt the data.
+	cipher.Encrypt(encryptedAddressIndex, addressIndex)
+
+	hint, err := genAddressTagHint(cipherTagSecret, encryptedAddressIndex)
+	if err != nil {
+		return nil, err
+	}
+	copy(encryptedAddressIndexAndHint[cipher.BlockSize():], hint)
+
+	a := &Address{
+		K1:  K1,
+		K2:  K2,
+		K3:  K3,
+		Tag: encryptedAddressIndexAndHint,
+	}
+
+	return a, nil
+}
+
+func genAddressTagHint(cipherKey []byte, encryptedAddressIndex []byte) ([]byte, error) {
+	// assemble hash contents: prefix || 'domain-sep' || k || cipher[k](j)
+	const domainSeparator = "jamtis_address_tag_hint"
+	return blake2bHash(nil, 2, prefix, domainSeparator, cipherKey, encryptedAddressIndex)
+}
+
+func genJamtisAddressSpendKey(spendPubKey []byte, generateAddress []byte, j []byte) ([]byte, error) {
+
+	// K_1 = k^j_g G + k^j_x X + k^j_u U + K_s
+
+	//k^j_u
+	addressExtensionKeyU, err := genJamtisSpendKeyExtension(hashKeyJamtisSpendKeyExtensionU, spendPubKey, generateAddress, j)
+	if err != nil {
+		return nil, err
+	}
+
+	//k^j_x
+	addressExtensionKeyX, err := genJamtisSpendKeyExtension(hashKeyJamtisSpendKeyExtensionX, spendPubKey, generateAddress, j)
+	if err != nil {
+		return nil, err
+	}
+
+	//k^j_g
+	addressExtensionKeyG, err := genJamtisSpendKeyExtension(hashKeyJamtisSpendKeyExtensionG, spendPubKey, generateAddress, j)
+	if err != nil {
+		return nil, err
+	}
+
+	extendedSeraphisSpendKey, err := new(ed25519.Point).SetBytes(spendPubKey)
+	if err != nil {
+		return nil, err
+	}
+
+	//k^j_u U + K_s
+	extendSeraphisSpendKey(addressExtensionKeyU, getUPoint(), extendedSeraphisSpendKey)
+
+	//k^j_x X + (k^j_u U + K_s)
+	extendSeraphisSpendKey(addressExtensionKeyX, getXPoint(), extendedSeraphisSpendKey)
+
+	//k^j_g G + (k^j_x X + k^j_u U + K_s)
+	extendedSeraphisSpendKey.Add(extendedSeraphisSpendKey, new(ed25519.Point).ScalarBaseMult(addressExtensionKeyG))
+
+	return extendedSeraphisSpendKey.Bytes(), nil
+}
+
+func extendSeraphisSpendKey(
+	addressExtensionKey *ed25519.Scalar,
+	generatorPt *ed25519.Point,
+	addressSpendKeyInOut *ed25519.Point,
+) {
+	extenderKey := new(ed25519.Point).ScalarMult(addressExtensionKey, generatorPt)
+	addressSpendKeyInOut.Add(addressSpendKeyInOut, extenderKey)
+}
+
+func blake2bHash(optionalKey []byte, hashSize int, inputs ...any) ([]byte, error) {
+	h, err := blake2b.New(hashSize, optionalKey)
+	if err != nil {
+		return nil, err
+	}
+
+	for _, input := range inputs {
+		var inputBytes []byte
+		switch arg := input.(type) {
+		case string:
+			inputBytes = []byte(arg)
+		case []byte:
+			inputBytes = arg
+		case *ed25519.Scalar:
+			inputBytes = arg.Bytes()
+		case *ed25519.Point:
+			inputBytes = arg.Bytes()
+		default:
+			panic("invalid hash input type")
+		}
+
+		_, err = h.Write(inputBytes)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	return h.Sum(nil), nil
+}
+
+func genJamtisSpendKeyExtension(
+	domainSeparator string,
+	spendPubKey []byte,
+	generatorAddress []byte,
+	j []byte, // 16-byte address index
+) (*ed25519.Scalar, error) {
+
+	// s^j_gen
+	generator, err := blake2bHash(generatorAddress, 32, prefix, hashKeyJamtisIndexExtensionGenerator, j)
+	if err != nil {
+		return nil, err
+	}
+
+	// k^j_?
+	extensionOut, err := blake2bHash(nil, 64, prefix, domainSeparator, spendPubKey, j, generator)
+	if err != nil {
+		return nil, err
+	}
+
+	return new(ed25519.Scalar).SetCanonicalBytes(mcrypto.ScReduce32(extensionOut))
+}
+
+func genJamtisAddressPrivKey(
+	spendPubKey []byte,
+	generateAddressPrivKey []byte,
+	addressIndex []byte,
+) ([]byte, error) {
+	generator, err := genJamtisIndexExtensionGenerator(generateAddressPrivKey, addressIndex)
+	if err != nil {
+		return nil, err
+	}
+
+	// xk^j_a = H_n_x25519(K_s, j, H_32[s_ga](j))
+	const domainSeparator = "jamtis_address_privkey"
+	addressPrivKeyOut, err := blake2bHash(nil, 32, prefix, domainSeparator, spendPubKey, addressIndex, generator)
+	if err != nil {
+		return nil, err
+	}
+
+	addressPrivKeyOut[0] &= 255 - 7
+	addressPrivKeyOut[31] &= 127
+
+	return addressPrivKeyOut, nil
+}
+
+func genJamtisIndexExtensionGenerator(
+	generateAddressSecret []byte,
+	addressIndex []byte,
+) ([]byte, error) {
+	const domainSeparator = "jamtis_index_extension_generator"
+	return blake2bHash(generateAddressSecret, 32, prefix, domainSeparator, addressIndex)
 }

--- a/jamtis/jamtis_test.go
+++ b/jamtis/jamtis_test.go
@@ -43,38 +43,38 @@ func TestJamtisKeys(t *testing.T) {
 	masterKey, err := hex.DecodeString(tc.masterKey)
 	require.NoError(t, err)
 
-	viewBalanceKey, err := genViewBalanceKey(masterKey)
+	viewBalanceKey, err := GenViewBalancePrivKey(masterKey)
 	require.NoError(t, err)
 	require.Equal(t, tc.viewBalanceKey, hex.EncodeToString(viewBalanceKey))
 
-	unlockAmountsPrivKey, err := genUnlockAmountsKey(viewBalanceKey)
+	unlockAmountsPrivKey, err := GenUnlockAmountsPrivKey(viewBalanceKey)
 	require.NoError(t, err)
 	require.Equal(t, tc.unlockAmountsKey, hex.EncodeToString(unlockAmountsPrivKey))
 
-	findReceivedPrivKey, err := genFindReceivedKey(viewBalanceKey)
+	findReceivedPrivKey, err := GenFindReceivedPrivKey(viewBalanceKey)
 	require.NoError(t, err)
 	require.Equal(t, tc.findReceivedKey, hex.EncodeToString(findReceivedPrivKey))
 
-	genAddressSecret, err := genGenAddressSecret(viewBalanceKey)
+	genAddressSecret, err := GenGenAddressSecret(viewBalanceKey)
 	require.NoError(t, err)
 	require.Equal(t, tc.generateAddressSecret, hex.EncodeToString(genAddressSecret))
 
-	cipherTagSecret, err := genCipherTagSecret(genAddressSecret)
+	cipherTagSecret, err := GenCipherTagSecret(genAddressSecret)
 	require.NoError(t, err)
 	require.Equal(t, tc.cipherTagSecret, hex.EncodeToString(cipherTagSecret))
 
-	spendKeyBase, err := genSeraphisSpendKey(viewBalanceKey, masterKey)
+	spendKeyBase, err := GenSeraphisSpendKey(viewBalanceKey, masterKey)
 	require.NoError(t, err)
 	require.Equal(t, tc.jamtisSpendKeyBase, hex.EncodeToString(spendKeyBase))
 
-	unlockAmountsPubKey := genUnlockAmountsPubKey(unlockAmountsPrivKey)
+	unlockAmountsPubKey := GenUnlockAmountsPubKey(unlockAmountsPrivKey)
 	require.Equal(t, tc.unlockAmountsPubKey, hex.EncodeToString(unlockAmountsPubKey))
 
-	findReceivedPubKey := genFindReceivedPubKey(findReceivedPrivKey, unlockAmountsPubKey)
+	findReceivedPubKey := GenFindReceivedPubKey(findReceivedPrivKey, unlockAmountsPubKey)
 	require.Equal(t, tc.findReceivedPubKey, hex.EncodeToString(findReceivedPubKey))
 
-	j := [16]byte{1}
-	address, err := genJamtisAddressV1(spendKeyBase, unlockAmountsPubKey, findReceivedPubKey, genAddressSecret, j[:])
+	j := [AddressIndexLen]byte{1}
+	address, err := GenJamtisAddressV1(spendKeyBase, unlockAmountsPubKey, findReceivedPubKey, genAddressSecret, j[:])
 	require.NoError(t, err)
 	require.Equal(t, tc.addressK1, hex.EncodeToString(address.K1[:]))
 	require.Equal(t, tc.addressK2, hex.EncodeToString(address.K2[:]))

--- a/jamtis/jamtis_test.go
+++ b/jamtis/jamtis_test.go
@@ -17,6 +17,10 @@ type testCase struct {
 	jamtisSpendKeyBase    string
 	unlockAmountsPubKey   string
 	findReceivedPubKey    string
+	addressK1             string
+	addressK2             string
+	addressK3             string
+	addressTag            string
 }
 
 var tc = testCase{
@@ -29,6 +33,10 @@ var tc = testCase{
 	jamtisSpendKeyBase:    "bd829d74e26dd91a8b16f774b8799c8742bbeb9d25ff7e1a57449dc9e5411d79",
 	unlockAmountsPubKey:   "437e2a1e5896afd6df54041ff5d9a18fe25814027ccc4a800493910a3f731907",
 	findReceivedPubKey:    "37c2d38f79503b9cd4f2685d4aa567fb42e470552866fee1bdf2bb4693054057",
+	addressK1:             "2a253091a8005d6ccb3326bb92b0b04eb3e6f0028abe1a66d242e2c5683efe47",
+	addressK2:             "dfd0a4f919cef620405ebbd27efe084b7bfb149a01365a13c14a2a3d0ffb4c75",
+	addressK3:             "5f5174d730d818f30de3a814c1148b488ed3addb2547f73f0e744ef3e7878246",
+	addressTag:            "a435a7bf8076247e6976d48f32e003adcaa9",
 }
 
 func TestJamtisKeys(t *testing.T) {
@@ -39,29 +47,37 @@ func TestJamtisKeys(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, tc.viewBalanceKey, hex.EncodeToString(viewBalanceKey))
 
-	unlockAmountsKey, err := genUnlockAmountsKey(viewBalanceKey)
+	unlockAmountsPrivKey, err := genUnlockAmountsKey(viewBalanceKey)
 	require.NoError(t, err)
-	require.Equal(t, tc.unlockAmountsKey, hex.EncodeToString(unlockAmountsKey))
+	require.Equal(t, tc.unlockAmountsKey, hex.EncodeToString(unlockAmountsPrivKey))
 
-	findReceivedKey, err := genFindReceivedKey(viewBalanceKey)
+	findReceivedPrivKey, err := genFindReceivedKey(viewBalanceKey)
 	require.NoError(t, err)
-	require.Equal(t, tc.findReceivedKey, hex.EncodeToString(findReceivedKey))
+	require.Equal(t, tc.findReceivedKey, hex.EncodeToString(findReceivedPrivKey))
 
 	genAddressSecret, err := genGenAddressSecret(viewBalanceKey)
 	require.NoError(t, err)
 	require.Equal(t, tc.generateAddressSecret, hex.EncodeToString(genAddressSecret))
 
-	genCipherTagSecret, err := genCipherTagSecret(genAddressSecret)
+	cipherTagSecret, err := genCipherTagSecret(genAddressSecret)
 	require.NoError(t, err)
-	require.Equal(t, tc.cipherTagSecret, hex.EncodeToString(genCipherTagSecret))
+	require.Equal(t, tc.cipherTagSecret, hex.EncodeToString(cipherTagSecret))
 
 	spendKeyBase, err := genSeraphisSpendKey(viewBalanceKey, masterKey)
 	require.NoError(t, err)
 	require.Equal(t, tc.jamtisSpendKeyBase, hex.EncodeToString(spendKeyBase))
 
-	unlockAmountsPubKey := genUnlockAmountsPubKey(unlockAmountsKey)
+	unlockAmountsPubKey := genUnlockAmountsPubKey(unlockAmountsPrivKey)
 	require.Equal(t, tc.unlockAmountsPubKey, hex.EncodeToString(unlockAmountsPubKey))
 
-	findReceivedPubKey := genFindReceivedPubKey(findReceivedKey, unlockAmountsPubKey)
+	findReceivedPubKey := genFindReceivedPubKey(findReceivedPrivKey, unlockAmountsPubKey)
 	require.Equal(t, tc.findReceivedPubKey, hex.EncodeToString(findReceivedPubKey))
+
+	j := [16]byte{1}
+	address, err := genJamtisAddressV1(spendKeyBase, unlockAmountsPubKey, findReceivedPubKey, genAddressSecret, j[:])
+	require.NoError(t, err)
+	require.Equal(t, tc.addressK1, hex.EncodeToString(address.K1[:]))
+	require.Equal(t, tc.addressK2, hex.EncodeToString(address.K2[:]))
+	require.Equal(t, tc.addressK3, hex.EncodeToString(address.K3[:]))
+	require.Equal(t, tc.addressTag, hex.EncodeToString(address.Tag))
 }

--- a/jamtis/seraphis.go
+++ b/jamtis/seraphis.go
@@ -32,8 +32,8 @@ func getXPoint() *ed25519.Point {
 	return X
 }
 
-// genSeraphisSpendKey returns the ed25519 calculation viewBalance*X + masterKey*U
-func genSeraphisSpendKey(viewBalanceKey []byte, masterKey []byte) ([]byte, error) {
+// GenSeraphisSpendKey returns the ed25519 calculation viewBalance*X + masterKey*U
+func GenSeraphisSpendKey(viewBalanceKey []byte, masterKey []byte) ([]byte, error) {
 	// Normally, you would call SetBytesWithClamping to get the reduced values,
 	// but it has additional bit modifications that are incompatible with
 	// Monero, so we do the reduce ourselves and call SetCanonicalBytes instead.


### PR DESCRIPTION
Adds support for generated Jamtis addresses (all Jamtis addresses are sub-addresses). The base32 human readable form is not yet available, as the Monero core developers are still debating the final syntax.